### PR TITLE
[Publications] Update URL to final BLeak paper.

### DIFF
--- a/src/data/publications.json
+++ b/src/data/publications.json
@@ -1,8 +1,8 @@
 [
     {
-    "url": "https://github.com/plasma-umass/BLeak/blob/master/paper.pdf",
+    "url": "https://dl.acm.org/citation.cfm?id=3192376",
     "title": "BLeak: Automatically Debugging Memory Leaks in Web Applications",
-    "author": "John Vilk and Emery Berger, University of Massachusetts Amherst. To appear, PLDI 2018",
+    "author": "John Vilk and Emery Berger, University of Massachusetts Amherst. PLDI 2018",
     "date" : "Jun 2018",
     "type" : "research"
   },


### PR DESCRIPTION
The PLDI proceedings are now available, and contain the final version of our paper. I'm updating the link to point to its official entry in the ACM digital library.