### PR TITLE
Added IEEE ISCC paper (mitmproxy2 with custom script to handle SFC)

### DIFF
--- a/src/data/publications.json
+++ b/src/data/publications.json
@@ -13,7 +13,14 @@
     "date" : "Jul 2018",
     "type" : "blog post"
   },
-    {
+  {
+    "url": "https://doi.org/10.1109/ISCC.2018.8538564",
+    "title": "An SFC-enabled approach for processing SSL/TLS encrypted traffic in Future Enterprise Networks",
+    "author": "Vitor A. Cunha, Marcio B. Carvalho, Daniel Corujo, Joao P. Barraca, Diogo Gomes, Alberto E. Schaeffer-Filho, Carlos R. P. dos Santos, Lisandro Z. Granville, and Rui L. Aguiar, IEEE ISCC 2018",
+    "date" : "Jun 2018",
+    "type" : "research"
+  },
+  {
     "url": "https://dl.acm.org/citation.cfm?id=3192376",
     "title": "BLeak: Automatically Debugging Memory Leaks in Web Applications",
     "author": "John Vilk and Emery Berger, University of Massachusetts Amherst. PLDI 2018",


### PR DESCRIPTION
Hi,

Please add our IEEE ISCC 2018 paper, which uses the (old) mitmproxy 2.0.2 with a (large) custom script to handle the SFC part. We apologize beforehand for not realizing you actually had a bibliographic reference that should be used, being your project briefly approached in the body of the article (with a link to your website available as a footnote of that text).

Your work has been an amazing tool to support our research, we cannot thank your team enough for the extensible design of mitmproxy.

Best regards,
Vitor Cunha