### PR TITLE
Mention HTTP/3 support on homepage

### DIFF
--- a/src/content/_index.html
+++ b/src/content/_index.html
@@ -116,7 +116,7 @@ title: "mitmproxy - an interactive HTTPS proxy"
                             privacy measurements, and penetration testing.
                             It can be used to intercept, inspect, modify and replay web traffic such
                             as
-                            HTTP/1, HTTP/2, WebSockets, or any other SSL/TLS-protected protocols.
+                            HTTP/1, HTTP/2, HTTP/3, WebSockets, or any other SSL/TLS-protected protocols.
                             You can prettify and decode a variety of message types ranging from HTML
                             to
                             Protobuf,


### PR DESCRIPTION
This is a follow-up based on the blog post
https://mitmproxy.org/posts/releases/mitmproxy-11/